### PR TITLE
Fix IOOB in DrawSingleWall and DrawBasicTile

### DIFF
--- a/Content/Optimizations/Tiles/ModifiedTileDrawing.cs
+++ b/Content/Optimizations/Tiles/ModifiedTileDrawing.cs
@@ -774,10 +774,20 @@ internal static class ModifiedTileDrawing
 
         if (!TileID.Sets.Platforms[drawData.typeCache] && !TileID.Sets.IgnoresNearbyHalfbricksWhenDrawn[drawData.typeCache] && td._tileSolid[drawData.typeCache] && !TileID.Sets.NotReallySolid[drawData.typeCache] && !drawData.tileCache.halfBrick())
         {
+            if ((tileX - 1) < 0)
+            {
+                return;
+            }
+
             tile = Main.tile[tileX - 1, tileY];
 
             if (!tile.halfBrick())
             {
+                if ((tileX + 1) >= Main.tile.Width)
+                {
+                    return;
+                }
+
                 tile = Main.tile[tileX + 1, tileY];
 
                 if (!tile.halfBrick())

--- a/Content/Optimizations/Tiles/ModifiedWallDrawing.cs
+++ b/Content/Optimizations/Tiles/ModifiedWallDrawing.cs
@@ -22,6 +22,12 @@ internal class ModifiedWallDrawing
 
         ushort wall = tile.wall;
 
+        // WallDrawing.FullTile accesses the tiles at (i - 1) and (i + 1)
+        if ((i - 1) < 0 || (i + 1) >= wd._tileArray.Width)
+        {
+            return;
+        }
+
         if (wall <= 0 || wd.FullTile(i, j) || (wall == 318 && !wd._shouldShowInvisibleWalls) || (tile.invisibleWall() && !wd._shouldShowInvisibleWalls))
         {
             return;


### PR DESCRIPTION
`ModifiedWallDrawing.DrawSingleWall` and `ModifiedTileDrawing.DrawBasicTile` didn't properly check indices before accessing tilemaps, resulting in a crash if the outermost chunk in a world - located in the offscreen buffer tiles - was attempted to be drawn. This occurs when one teleports to a location close to the edge of the world because the camera is temporarily further left than if one just walked there.

I have not performed an extensive search through tile rendering for possible IOOBs - I fixed these two because they occured as part of the aforementioned crash. The same approach should be adequate for solving any future similar crashes.