### PR TITLE
Squash Reported Build Warnings

### DIFF
--- a/Content/Optimizations/MiscSimd/MiscSimdApplicationSystem.cs
+++ b/Content/Optimizations/MiscSimd/MiscSimdApplicationSystem.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+﻿/*using JetBrains.Annotations;
 using MonoMod.Cil;
 using Nitrate.Core.Utilities;
 using Terraria.ModLoader;
@@ -20,4 +20,5 @@ internal sealed class MiscSimdApplicationSystem : ModSystem
         ILCursor c = new(il);
         c.Simdify();
     }
-}
+}*/
+

--- a/Content/Optimizations/ParallelizedUpdating/LightingParallelismSystem.cs
+++ b/Content/Optimizations/ParallelizedUpdating/LightingParallelismSystem.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using Nitrate.Core.Threading;
+using ReLogic.Threading;
 using System;
 using Terraria;
 using Terraria.Graphics.Light;
@@ -80,7 +81,7 @@ internal sealed class LightingParallelismSystem : ModSystem
             {
                 self._drawInvisibleWalls = options.DrawInvisibleWalls;
 
-                FasterParallel.For(area.Left, area.Right, delegate (int start, int end, object context)
+                FasterParallel.For(area.Left, area.Right, delegate (int start, int end, object _)
                 {
                     for (int i = start; i < end; i++)
                     {

--- a/Content/Optimizations/Tiles/ChunkSystem.cs
+++ b/Content/Optimizations/Tiles/ChunkSystem.cs
@@ -20,11 +20,12 @@ namespace Nitrate.Content.Optimizations.Tiles;
 /// TODO:
 /// Make sure other effects such as dusts/tile cracks are rendered as well.
 /// Ensure water squares can draw behind tiles.
-/// Maybe make RenderTiles2 still run for the nonsolid layer and tile deco/animated tiles?
+/// Maybe make RenderTiles2 still run for the non-solid layer and tile deco/animated tiles?
 /// </summary>
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
 internal sealed class ChunkSystem : ModSystem
 {
+    [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
     private sealed class WarningSystem : ModPlayer
     {
         public override void OnEnterWorld()
@@ -60,13 +61,13 @@ internal sealed class ChunkSystem : ModSystem
 
     private readonly Lazy<Effect> _lightMapRenderer;
 
-    private RenderTarget2D _lightingBuffer;
+    private RenderTarget2D? _lightingBuffer;
 
-    private Color[] _colorBuffer;
+    private Color[] _colorBuffer = Array.Empty<Color>();
 
-    private RenderTarget2D _chunkScreenTarget;
+    private RenderTarget2D? _chunkScreenTarget;
 
-    private RenderTarget2D _screenSizeLightingBuffer;
+    private RenderTarget2D? _screenSizeLightingBuffer;
 
     private bool _enabled;
 
@@ -115,7 +116,7 @@ internal sealed class ChunkSystem : ModSystem
             _chunkScreenTarget = new RenderTarget2D(Main.graphics.GraphicsDevice, Main.screenWidth, Main.screenHeight);
             _screenSizeLightingBuffer = new RenderTarget2D(Main.graphics.GraphicsDevice, Main.screenWidth, Main.screenHeight);
 
-            // By default Terraria has this set to DiscardContents. This means that switching RTs erases the contents of the backbuffer if done mid-draw.
+            // By default, Terraria has this set to DiscardContents. This means that switching RTs erases the contents of the backbuffer if done mid-draw.
             Main.graphics.GraphicsDevice.PresentationParameters.RenderTargetUsage = RenderTargetUsage.PreserveContents;
             Main.graphics.ApplyChanges();
         });
@@ -153,7 +154,7 @@ internal sealed class ChunkSystem : ModSystem
         {
             foreach (RenderTarget2D chunk in _loadedChunks.Values)
             {
-                chunk?.Dispose();
+                chunk.Dispose();
             }
         });
 
@@ -244,7 +245,7 @@ internal sealed class ChunkSystem : ModSystem
 
     private void PopulateLightingBuffer()
     {
-        if (_colorBuffer is null || _lightingBuffer is null)
+        if (_lightingBuffer is null)
         {
             return;
         }
@@ -510,7 +511,7 @@ internal sealed class ChunkSystem : ModSystem
         {
             foreach (RenderTarget2D chunk in _loadedChunks.Values)
             {
-                chunk?.Dispose();
+                chunk.Dispose();
             }
 
             _lightingBuffer?.Dispose();

--- a/Core/UI/MainMenuRenderer.cs
+++ b/Core/UI/MainMenuRenderer.cs
@@ -19,7 +19,7 @@ internal sealed class MainMenuRenderer : ModSystem
 {
     private static GameTime? GameTime;
 
-    public UserInterface UserInterface { get; } = new();
+    private UserInterface UserInterface { get; } = new();
 
     public override void Load()
     {
@@ -102,6 +102,8 @@ internal sealed class MainMenuRenderer : ModSystem
         drawText($".NET Version: {Environment.Version}", new FnaVector2(padding, debugBox.Y + charHeight * small_text_scale), Color.White, 0f, FnaVector2.Zero, new FnaVector2(small_text_scale));
         drawText($"OS: {Environment.OSVersion.ToString().Replace("Microsoft ", "")}", new FnaVector2(padding, debugBox.Y + charHeight * small_text_scale * 2), Color.White, 0f, FnaVector2.Zero, new FnaVector2(small_text_scale));
         drawText($"Architecture: {(Environment.Is64BitOperatingSystem ? "x64" : "x86")}", new FnaVector2(padding, debugBox.Y + charHeight * small_text_scale * 3), Color.White, 0f, FnaVector2.Zero, new FnaVector2(small_text_scale));
+
+        return;
 
         void drawText(string text, FnaVector2 position, Color baseColor, float rotation, FnaVector2 origin, FnaVector2 baseScale)
         {

--- a/Nitrate.csproj
+++ b/Nitrate.csproj
@@ -8,6 +8,11 @@
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
+
+        <!-- Ignore duplicate type definitions from dependencies because
+             MonoMod.Utils and our publicizer package we use both define
+             IgnoresAccessChecksToAttribute. -->
+        <NoWarn>CS0436</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Nitrate.sln.DotSettings
+++ b/Nitrate.sln.DotSettings
@@ -8,4 +8,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=simdifiers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Simdifies/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Simdify/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Terraria/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tomatophile/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Clean up some warnings about nullability. Also hide a redundant warning about multiple polyfilled types being provided.