### PR TITLE
Optimize pylon network

### DIFF
--- a/Content/Optimizations/GameLogic/FasterPylonSystem.cs
+++ b/Content/Optimizations/GameLogic/FasterPylonSystem.cs
@@ -1,0 +1,74 @@
+﻿using JetBrains.Annotations;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using MonoMod.Cil;
+using System;
+using System.Linq;
+using System.Reflection.Emit;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.ModLoader;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
+
+namespace Nitrate.Content.Optimizations.GameLogic;
+
+/// <summary>
+/// Optimizes internal code for pylons.
+/// </summary>
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
+public class FasterPylonSystem : ModSystem
+{
+	public override void OnModLoad()
+	{
+		base.OnModLoad();
+
+		IL_TeleportPylonsSystem.IsPlayerNearAPylon += SpeedUpIsPlayerNearAPylon;
+	}
+
+	/// <summary>
+	/// The vanilla implementation of <see cref="TeleportPylonsSystem.IsPlayerNearAPylon"/> uses the <see cref="Player.IsTileTypeInInteractionRange"/>
+	/// method to find if any pylon is nearby the player.
+	///
+	/// The problem:
+	/// A single invocation of this method can (and usually does) perform over 14,000 tile lookups.
+	///
+	/// The solution:
+	/// Instead of searching for nearby pylons from the player, search for the player from every pylon.
+	/// The game limits the amount of pylons that can be placed, putting an upper bound on the potential downside of this operation.
+	///
+	/// Results:
+	/// From testing, the original method would perform at an average of 0.5ms per invocation.
+	/// The updated method reduces this to 0.005ms per invocation on average
+	/// </summary>
+	/// <param name="il"></param>
+	private static void SpeedUpIsPlayerNearAPylon(ILContext il)
+	{
+		ILCursor cursor = new(il);
+		cursor.Emit(OpCodes.Ldarg_0);
+
+		cursor.EmitDelegate<Func<Player, bool>>(player =>
+		{
+			foreach (TeleportPylonInfo info in Main.PylonSystem.Pylons) {
+				Point16 point = info.PositionInTiles;
+				Point16 lowerRightPylonPoint = new(point.X + 2, point.Y + 3);
+
+				Point playerPoint = player.position.ToTileCoordinates();
+
+				TileReachCheckSettings.Pylons.GetRanges(player, out int x, out int y);
+				int minRangeX = Utils.Clamp(point.X - x, 0, Main.maxTilesX - 1);
+				int maxRangeX = Utils.Clamp(lowerRightPylonPoint.X + x - 1, 0, Main.maxTilesX - 1);
+				int minRangeY = Utils.Clamp(point.Y - y - 1, 0, Main.maxTilesY - 1);
+				int maxRangeY = Utils.Clamp(lowerRightPylonPoint.Y + y - 1, 0, Main.maxTilesY - 1);
+
+				if (playerPoint.X >= minRangeX && playerPoint.X <= maxRangeX &&
+				    playerPoint.Y >= minRangeY && playerPoint.Y <= maxRangeY)
+					return true;
+			}
+			return false;
+		});
+
+		cursor.Emit(OpCodes.Ret);
+	}
+}

--- a/Content/Optimizations/GameLogic/FasterPylonSystem.cs
+++ b/Content/Optimizations/GameLogic/FasterPylonSystem.cs
@@ -1,74 +1,84 @@
 ﻿using JetBrains.Annotations;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Input;
+using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using System;
-using System.Linq;
-using System.Reflection.Emit;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent;
-using Terraria.ID;
 using Terraria.ModLoader;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
 
 namespace Nitrate.Content.Optimizations.GameLogic;
 
 /// <summary>
-/// Optimizes internal code for pylons.
+///     Optimizes internal code for pylons.
 /// </summary>
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
 public class FasterPylonSystem : ModSystem
 {
-	public override void OnModLoad()
-	{
-		base.OnModLoad();
+    public override void OnModLoad()
+    {
+        base.OnModLoad();
 
-		IL_TeleportPylonsSystem.IsPlayerNearAPylon += SpeedUpIsPlayerNearAPylon;
-	}
+        IL_TeleportPylonsSystem.IsPlayerNearAPylon += SpeedUpIsPlayerNearAPylon;
+    }
 
-	/// <summary>
-	/// The vanilla implementation of <see cref="TeleportPylonsSystem.IsPlayerNearAPylon"/> uses the <see cref="Player.IsTileTypeInInteractionRange"/>
-	/// method to find if any pylon is nearby the player.
-	///
-	/// The problem:
-	/// A single invocation of this method can (and usually does) perform over 14,000 tile lookups.
-	///
-	/// The solution:
-	/// Instead of searching for nearby pylons from the player, search for the player from every pylon.
-	/// The game limits the amount of pylons that can be placed, putting an upper bound on the potential downside of this operation.
-	///
-	/// Results:
-	/// From testing, the original method would perform at an average of 0.5ms per invocation.
-	/// The updated method reduces this to 0.005ms per invocation on average
-	/// </summary>
-	/// <param name="il"></param>
-	private static void SpeedUpIsPlayerNearAPylon(ILContext il)
-	{
-		ILCursor cursor = new(il);
-		cursor.Emit(OpCodes.Ldarg_0);
+    /// <summary>
+    ///     The vanilla implementation of
+    ///     <see cref="TeleportPylonsSystem.IsPlayerNearAPylon"/> uses the
+    ///     <see cref="Player.IsTileTypeInInteractionRange"/> method to find if
+    ///     any pylon is nearby the player.
+    ///     <br />
+    ///     The problem:
+    ///     <br />
+    ///     A single invocation of this method can (and usually does) perform
+    ///     over 14,000 tile lookups.
+    ///     <br />
+    ///     The solution:
+    ///     <br />
+    ///     Instead of searching for nearby pylons from the player, search for
+    ///     the player from every pylon. The game limits the amount of pylons
+    ///     that can be placed, putting an upper bound on the potential downside
+    ///     of this operation.
+    ///     <br />
+    ///     Results:
+    ///     <br />
+    ///     From testing, the original method would perform at an average of
+    ///     0.5ms per invocation.
+    ///     <br />
+    ///     The updated method reduces this to 0.005ms per invocation on
+    ///     average.
+    /// </summary>
+    private static void SpeedUpIsPlayerNearAPylon(ILContext il)
+    {
+        ILCursor cursor = new(il);
+        cursor.Emit(OpCodes.Ldarg_0);
 
-		cursor.EmitDelegate<Func<Player, bool>>(player =>
-		{
-			foreach (TeleportPylonInfo info in Main.PylonSystem.Pylons) {
-				Point16 point = info.PositionInTiles;
-				Point16 lowerRightPylonPoint = new(point.X + 2, point.Y + 3);
+        cursor.EmitDelegate<Func<Player, bool>>(player =>
+        {
+            foreach (TeleportPylonInfo info in Main.PylonSystem.Pylons)
+            {
+                Point16 point = info.PositionInTiles;
+                Point16 lowerRightPylonPoint = new(point.X + 2, point.Y + 3);
 
-				Point playerPoint = player.position.ToTileCoordinates();
+                Point playerPoint = player.position.ToTileCoordinates();
 
-				TileReachCheckSettings.Pylons.GetRanges(player, out int x, out int y);
-				int minRangeX = Utils.Clamp(point.X - x, 0, Main.maxTilesX - 1);
-				int maxRangeX = Utils.Clamp(lowerRightPylonPoint.X + x - 1, 0, Main.maxTilesX - 1);
-				int minRangeY = Utils.Clamp(point.Y - y - 1, 0, Main.maxTilesY - 1);
-				int maxRangeY = Utils.Clamp(lowerRightPylonPoint.Y + y - 1, 0, Main.maxTilesY - 1);
+                TileReachCheckSettings.Pylons.GetRanges(player, out int x, out int y);
+                int minRangeX = Utils.Clamp(point.X - x, 0, Main.maxTilesX - 1);
+                int maxRangeX = Utils.Clamp(lowerRightPylonPoint.X + x - 1, 0, Main.maxTilesX - 1);
+                int minRangeY = Utils.Clamp(point.Y - y - 1, 0, Main.maxTilesY - 1);
+                int maxRangeY = Utils.Clamp(lowerRightPylonPoint.Y + y - 1, 0, Main.maxTilesY - 1);
 
-				if (playerPoint.X >= minRangeX && playerPoint.X <= maxRangeX &&
-				    playerPoint.Y >= minRangeY && playerPoint.Y <= maxRangeY)
-					return true;
-			}
-			return false;
-		});
+                if (playerPoint.X >= minRangeX &&
+                    playerPoint.X <= maxRangeX &&
+                    playerPoint.Y >= minRangeY &&
+                    playerPoint.Y <= maxRangeY)
+                    return true;
+            }
 
-		cursor.Emit(OpCodes.Ret);
-	}
+            return false;
+        });
+
+        cursor.Emit(OpCodes.Ret);
+    }
 }

--- a/Content/Optimizations/GameLogic/FasterPylonSystem.cs
+++ b/Content/Optimizations/GameLogic/FasterPylonSystem.cs
@@ -29,10 +29,12 @@ public class FasterPylonSystem : ModSystem
     ///     <see cref="Player.IsTileTypeInInteractionRange"/> method to find if
     ///     any pylon is nearby the player.
     ///     <br />
+    ///     <br />
     ///     The problem:
     ///     <br />
     ///     A single invocation of this method can (and usually does) perform
     ///     over 14,000 tile lookups.
+    ///     <br />
     ///     <br />
     ///     The solution:
     ///     <br />
@@ -40,6 +42,7 @@ public class FasterPylonSystem : ModSystem
     ///     the player from every pylon. The game limits the amount of pylons
     ///     that can be placed, putting an upper bound on the potential downside
     ///     of this operation.
+    ///     <br />
     ///     <br />
     ///     Results:
     ///     <br />
@@ -58,22 +61,21 @@ public class FasterPylonSystem : ModSystem
         {
             foreach (TeleportPylonInfo info in Main.PylonSystem.Pylons)
             {
-                Point16 point = info.PositionInTiles;
-                Point16 lowerRightPylonPoint = new(point.X + 2, point.Y + 3);
+                Point16 pos = info.PositionInTiles;
+                Point16 lowerRightPylonPoint = new(pos.X + 2, pos.Y + 3);
 
-                Point playerPoint = player.position.ToTileCoordinates();
+                Point playerPos = player.position.ToTileCoordinates();
 
                 TileReachCheckSettings.Pylons.GetRanges(player, out int x, out int y);
-                int minRangeX = Utils.Clamp(point.X - x, 0, Main.maxTilesX - 1);
+                int minRangeX = Utils.Clamp(pos.X - x, 0, Main.maxTilesX - 1);
                 int maxRangeX = Utils.Clamp(lowerRightPylonPoint.X + x - 1, 0, Main.maxTilesX - 1);
-                int minRangeY = Utils.Clamp(point.Y - y - 1, 0, Main.maxTilesY - 1);
+                int minRangeY = Utils.Clamp(pos.Y - y - 1, 0, Main.maxTilesY - 1);
                 int maxRangeY = Utils.Clamp(lowerRightPylonPoint.Y + y - 1, 0, Main.maxTilesY - 1);
 
-                if (playerPoint.X >= minRangeX &&
-                    playerPoint.X <= maxRangeX &&
-                    playerPoint.Y >= minRangeY &&
-                    playerPoint.Y <= maxRangeY)
+                if (playerPos.X >= minRangeX && playerPos.X <= maxRangeX && playerPos.Y >= minRangeY && playerPos.Y <= maxRangeY)
+                {
                     return true;
+                }
             }
 
             return false;

--- a/Content/Optimizations/GameLogic/README.md
+++ b/Content/Optimizations/GameLogic/README.md
@@ -1,0 +1,31 @@
+﻿# Optimizations: Game Logic
+
+Contains optimizations pertaining to generic game logic (specifically logic that does not belong to existing, established areas: tile rendering, parallelization, particle rendering, etc.).
+
+## `FasterPylonSystem`
+
+> Authored by:
+> - [@Golfing7](https://github.com/Golfing7)
+>
+> Implemented in:
+> - [GH-13](https://github.com/terraria-catalyst/Nitrate/pull/13)
+
+---
+
+The vanilla implementation of `TeleportPylonsSystem.IsPlayerNearAPylon` uses the `Player.IsTileTypeInInteractionRange` method to find if any pylon is nearby the player.
+
+### The Problem
+
+A single invocation of this method can (and usually does) perform over 14,000 tile lookups.
+
+### The Solution
+
+Instead of searching for nearby pylons from the player, search for the player from every pylon.
+The game limits the amount of pylons that can be placed[^1], putting an upper bound on the potential downside of this operation[^2].
+
+#### Results
+
+From testing, the original method would perform at an average of 0.5ms per invocation. The updated method reduces this to 0.005ms per invocation on average.
+
+[^1]: PENDING: What happens if a mod permits multiple types of the same pylon to be placed? Needs looking into.
+[^2]: Mods can, of course, add additional pylons, but this scales well enough and we will not end up with 14,000 pylons.

--- a/Core/UI/MainMenuRenderer.cs
+++ b/Core/UI/MainMenuRenderer.cs
@@ -8,7 +8,6 @@ using Terraria.GameContent;
 using Terraria.ModLoader;
 using Terraria.UI;
 using Terraria.UI.Chat;
-using Terraria.Localization;
 using Nitrate.Core.Utilities;
 
 namespace Nitrate.Core.UI;


### PR DESCRIPTION
This commit adds a transformer for the `SpeedUpIsPlayerNearAPylon` method within the `TeleportPylonsSystem` class.

Vanilla Terraria detects if a player is within a pylon network by checking all tiles within 60 tiles of the player's current position. This ends up causing upwards of 14,000 tile lookups if the method doesn't short-circuit, which happens to be most of the time considering players aren't near pylons often. This commit rewrites the method to reverse the search and search for the player from all active pylons. 

