### PR TITLE
Fixed tile PreDraw screen position bug

### DIFF
--- a/Optimizations/Tiles/ModifiedTileDrawing.cs
+++ b/Optimizations/Tiles/ModifiedTileDrawing.cs
@@ -76,9 +76,9 @@ internal static class ModifiedTileDrawing
                 Main.screenPosition -= new Vector2(Main.offScreenRange);
                 AddSpecialPointsForTile(tile, x, y);
                 DrawSingleTile_Inner(vanilla, solid, x, y, screenPosition, Vector2.Zero, tile, type);
+                Main.screenPosition += new Vector2(Main.offScreenRange);
             }
 
-            Main.screenPosition += new Vector2(Main.offScreenRange);
             TileLoader.PostDraw(j, i, type, Main.spriteBatch);
             Main.screenPosition -= new Vector2(Main.offScreenRange);
         }


### PR DESCRIPTION
Fixes an issue in ModifiedTileDrawing, where the screen position is incorrectly modified by the screen padding vector for the rest of the frame if TileLoader.PreDraw returns false.